### PR TITLE
bugfix: blobname of destination file

### DIFF
--- a/edc-ionos-extension/data-plane-ionos-s3/src/main/java/com/ionos/edc/dataplane/ionos/s3/IonosDataSink.java
+++ b/edc-ionos-extension/data-plane-ionos-s3/src/main/java/com/ionos/edc/dataplane/ionos/s3/IonosDataSink.java
@@ -33,18 +33,12 @@ public class IonosDataSink extends ParallelSink {
     private String accessKey;
     private String secretkey;
     
-    private IonosDataSink() {
-
-    }
+    private IonosDataSink() {}
 
     @Override
     protected StreamResult<Void> transferParts(List<DataSource.Part> parts) {
         for (DataSource.Part part : parts) {
-        	 String blobName = part.name();
-        
             try (var input = part.openStream()) {
-               
-               
                 s3Api.uploadParts(bucketName, blobName, new ByteArrayInputStream(input.readAllBytes()));
             } catch (Exception e) {
                 return uploadFailure(e, blobName);
@@ -62,7 +56,6 @@ public class IonosDataSink extends ParallelSink {
     }
 
     public static class Builder extends ParallelSink.Builder<Builder, IonosDataSink> {
-
         private Builder() {
             super(new IonosDataSink());
         }
@@ -90,15 +83,13 @@ public class IonosDataSink extends ParallelSink {
             sink.accessKey = accessKey;
             return this;
         }
+
         public Builder secretkey(String secretkey) {
             sink.secretkey = secretkey;
             return this;
         }
 
-
-
         @Override
-        protected void validate() {
-        }
+        protected void validate() {}
     }
 }


### PR DESCRIPTION
#### What type of PR is this?
bugfix

#### What this PR does / why we need it:
This PR fixes an issue with the data transfer. The current implementation uses the multiparts name as the `blobName` for the `s3Api.uploadParts`. Unfortunately `part.name()` does not contain the `DataDestination` name (target upload name) but instead the `DataSource` name of the original blob.

Fortunately, the upload is done as part of the `IonosDataSink` object which already has the `DataDestination` `blobName` configured through the builder pattern. Because of this the local variable `String blobName = part.name();` has to be removed to use the object field `blobName` instead. Which contains the correct value for the data transfer / upload.