### PR TITLE
fix: initialize Connector without IONOS Account

### DIFF
--- a/extensions/core-ionos-s3/src/main/java/com/ionos/edc/extension/s3/api/S3ConnectorApiImpl.java
+++ b/extensions/core-ionos-s3/src/main/java/com/ionos/edc/extension/s3/api/S3ConnectorApiImpl.java
@@ -46,16 +46,22 @@ public class S3ConnectorApiImpl implements S3ConnectorApi {
     private final String token;
     private final Integer maxFiles;
 
+
+
     public S3ConnectorApiImpl(String regionId, @NotNull String accessKey, @NotNull String secretKey, @NotNull String token, int maxFiles) {
         this.token = token;
         this.maxFiles = maxFiles;
 
         this.regionId = Objects.requireNonNullElse(regionId, REGION_ID_DEFAULT);
-        var endpoint = getEndpoint( this.regionId , token);
 
-        this.minioClient = miniConnector.connect(endpoint, accessKey, secretKey);
+        if(ionoss3Api.verifyToken(token)){
+            var endpoint = getEndpoint(this.regionId, token);
+            this.minioClient = miniConnector.connect(endpoint, accessKey, secretKey);
+        }else{
+            this.minioClient = null;
+
+        }
     }
-
     @Override
     public void createBucket(String bucketName) {
         if (!bucketExists(bucketName.toLowerCase())) {

--- a/extensions/core-ionos-s3/src/main/java/com/ionos/edc/extension/s3/connector/ionosapi/S3ApiConnector.java
+++ b/extensions/core-ionos-s3/src/main/java/com/ionos/edc/extension/s3/connector/ionosapi/S3ApiConnector.java
@@ -42,6 +42,9 @@ public class S3ApiConnector {
     }
 
     public boolean verifyToken(String token) {
+        if (token == null || token.isEmpty())
+            return false;
+
         String url = "https://api.ionos.com/cloudapi/v6/locations";
 
         Request request = new Request.Builder().url(url)

--- a/extensions/core-ionos-s3/src/main/java/com/ionos/edc/extension/s3/connector/ionosapi/S3ApiConnector.java
+++ b/extensions/core-ionos-s3/src/main/java/com/ionos/edc/extension/s3/connector/ionosapi/S3ApiConnector.java
@@ -41,6 +41,25 @@ public class S3ApiConnector {
         }
     }
 
+    public boolean verifyToken(String token) {
+        String url = "https://api.ionos.com/cloudapi/v6/locations";
+
+        Request request = new Request.Builder().url(url)
+                .addHeader("Authorization", "Bearer " + token)
+                .get()
+                .build();
+        try (Response response = client.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                return false;
+
+            } else return response.body() != null;
+        } catch (IOException e) {
+            throw new EdcException("Error access Ionos Cloud", e);
+
+        }
+    }
+
+
     public S3AccessKey createAccessKey(String token) {
         String url = BASE_URL + "/accesskeys";
 


### PR DESCRIPTION
Fix: initialize IONOS  s3 connector without IONOS s3 account