### PR TITLE
fix: initialize Connector without IONOS Account

### DIFF
--- a/extensions/core-ionos-s3/src/main/java/com/ionos/edc/extension/s3/api/S3ApiClient.java
+++ b/extensions/core-ionos-s3/src/main/java/com/ionos/edc/extension/s3/api/S3ApiClient.java
@@ -66,7 +66,23 @@ public class S3ApiClient {
             throw new EdcException("Error retrieving S3 accesskey", e);
         }
     }
+    public boolean verifyToken(String token) {
+        String url = "https://api.ionos.com/cloudapi/v6/locations";
 
+        Request request = new Request.Builder().url(url)
+                .addHeader("Authorization", "Bearer " + token)
+                .get()
+                .build();
+        try (Response response = client.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                return false;
+
+            } else return response.body() != null;
+        } catch (IOException e) {
+            throw new EdcException("Error access Ionos Cloud", e);
+
+        }
+    }
     public S3AccessKey createAccessKey(String token) {
 
         Request request = new Request.Builder().url(ACCESS_KEYS_ENDPOINT_URL)

--- a/extensions/core-ionos-s3/src/main/java/com/ionos/edc/extension/s3/api/S3ApiClient.java
+++ b/extensions/core-ionos-s3/src/main/java/com/ionos/edc/extension/s3/api/S3ApiClient.java
@@ -67,6 +67,9 @@ public class S3ApiClient {
         }
     }
     public boolean verifyToken(String token) {
+        if(token == null || token.isEmpty())
+            return false;
+
         String url = "https://api.ionos.com/cloudapi/v6/locations";
 
         Request request = new Request.Builder().url(url)

--- a/extensions/core-ionos-s3/src/main/java/com/ionos/edc/extension/s3/connector/S3ConnectorImpl.java
+++ b/extensions/core-ionos-s3/src/main/java/com/ionos/edc/extension/s3/connector/S3ConnectorImpl.java
@@ -50,9 +50,12 @@ public class S3ConnectorImpl implements S3Connector {
         this.maxFiles = maxFiles;
 
         this.regionId = Objects.requireNonNullElse(regionId, REGION_ID_DEFAULT);
-        var endpoint = getEndpoint( this.regionId , token);
-
-        this.minioClient = MinioClient.builder().endpoint(endpoint).credentials(accessKey, secretKey).build();
+        if(S3ApiClient.verifyToken(token)) {
+            var endpoint = getEndpoint(this.regionId, token);
+            this.minioClient = MinioClient.builder().endpoint(endpoint).credentials(accessKey, secretKey).build();
+        } else {
+            this.minioClient = null;
+        }
     }
 
     @Override


### PR DESCRIPTION
Fix: initialize IONOS s3 connector without IONOS s3 account (EDC 0.7.2)